### PR TITLE
Fix timer resetting on world hop

### DIFF
--- a/src/main/java/com/QSRAutoSplitter/QSRAutoSplitterPlugin.java
+++ b/src/main/java/com/QSRAutoSplitter/QSRAutoSplitterPlugin.java
@@ -57,6 +57,7 @@ public class QSRAutoSplitterPlugin extends Plugin
 	// is the timer running?
 	private boolean started = false;
 	private boolean paused = false;
+	private int initializeTimer = 2;
 
 	private List<Pair<Integer, Integer>> itemList;
 	private List<Pair<Integer, Integer>> varbList;
@@ -130,6 +131,10 @@ public class QSRAutoSplitterPlugin extends Plugin
 	}
 	@Subscribe
 	public void onGameTick(GameTick event) {
+		if (initializeTimer > 0) {
+			initializeTimer--;
+			return;
+		}
 		if (!started && isInSpeedrun()) {
 			started = true;
 			sendMessage("reset");
@@ -197,6 +202,9 @@ public class QSRAutoSplitterPlugin extends Plugin
 
 	@Subscribe
 	private void onGameStateChanged(GameStateChanged event) {
+		if (event.getGameState() == GameState.LOGGING_IN || event.getGameState() == GameState.HOPPING) {
+			initializeTimer = 2;
+		}
 		if (started) {
 			if (event.getGameState() == GameState.LOADING ||
 					event.getGameState() == GameState.LOGGED_IN ||


### PR DESCRIPTION
This attempts to fix the bug where the plugin incorrectly evaluates isInSpeedrun to true and causing it to start a new run, this is caused by the game client not always recieving varbits on the first tick on logging in.

I've attempted to fix this by delaying onGameTick by two ticks upon world hopping or logging in. This fix is based on a similar issue in core https://github.com/runelite/runelite/commit/265f801ef43060ca17b647644bafaccb713c56db

I realize I didn't copy that implimentation 1:1 and hanging the onGameTick is not ideal, but I couldn't get their implementation to work directly as I'm not proficient with java.

I would very much appreciate it if you could give this a look and merge or adjust the code as this plugin has essentially been unusuable for any quests that require world hopping.

I have tested this fix and can confirm the plugin behaves as expected in all cases I could find.